### PR TITLE
Add the new svg-image-element.js file to the build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,7 @@ files=( \
   lib/svg-shape-element.js \
   lib/svg-path-element.js \
   lib/svg-circle-element.js \
+  lib/svg-image-element.js \
   lib/vml-element.js \
   lib/vml-group-element.js \
   lib/vml-canvas-element.js \
@@ -51,4 +52,4 @@ fi
 
 cat ${files[*]} >> $minified
 
-uglifyjs --overwrite $minified
+uglifyjs $minified -o $minified


### PR DESCRIPTION
Now that npm has updated to use uglify-js version 2, it is probably wise to update the build to use it.
